### PR TITLE
Solve name confusion in prelude

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
 
 [[package]]
 name = "mongodm"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodm"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2018"
 description = "A thin ODM layer for mongodb"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,16 +220,14 @@ pub mod prelude {
         Database as MongoDatabase,
     };
     #[doc(no_inline)]
-    pub use crate::ToRepository as _;
+    pub use crate::ToRepository;
     #[doc(no_inline)]
     pub use crate::{
-        f, field, operator::*, pipeline, CollectionConfig, Index, IndexOption, Indexes, Model,
-        ModelCursor, Repository, SortOrder,
+        f, field, mongo::Cursor, operator::*, pipeline, sync_indexes, CollectionConfig, Index,
+        IndexOption, Indexes, Model, ModelCursor, Repository, SortOrder,
     };
     #[doc(no_inline)]
-    pub use futures_core::Stream;
+    pub use futures_util::future::{BoxFuture, FutureExt};
     #[doc(no_inline)]
-    pub use futures_util::FutureExt as _;
-    #[doc(no_inline)]
-    pub use futures_util::StreamExt as _;
+    pub use futures_util::StreamExt;
 }


### PR DESCRIPTION
This seems to solve some weird false-errors flagged by CLion when glob-importing the prelude.
At least, it fixes them for me (after invalidating the cache).
Did you have such issues too @CBenoit ?