### PR TITLE
Expose functionnalities on mongo collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.2] 2022-05-02
+
+### Changed
+
+- Expose `bulk_update` function to the native `mongodb::Collection` via an Extension Trait `CollectionExt`
+
+## [0.8.1] 2022-04-30
+
+### Changed
+
+- Fixed a typo in the `$subtract` operator
+
 ## [0.8.0] 2021-12-09
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Expose `bulk_update` function to the native `mongodb::Collection` via an Extension Trait `CollectionExt`
 
-## [0.8.1] 2022-04-30
-
-### Changed
+### Fixed
 
 - Fixed a typo in the `$subtract` operator
+
+## [0.8.1] 2022-03-31
+
+### Fixed
+
+- Fixed an issue with selection_criteria on the `Repository::bulk_update` function
 
 ## [0.8.0] 2021-12-09
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodm"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2018"
 description = "A thin ODM layer for mongodb"
@@ -16,6 +16,7 @@ mongodb = { version = "2", default-features = false }
 serde = { version = "1", features = ["derive"] }
 futures-core = "0.3"
 futures-util = "0.3"
+async-trait = "0.1"
 
 [dev-dependencies]
 tokio = "1.14.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,12 +221,11 @@ pub mod prelude {
         Database as MongoDatabase,
     };
     #[doc(no_inline)]
-    pub use crate::ToRepository;
-    #[doc(no_inline)]
     pub use crate::{
-        f, field, mongo::Cursor, operator::*, pipeline, sync_indexes, BulkUpdate, BulkUpdateResult,
+        f, field, operator::*, pipeline, sync_indexes, BulkUpdate, BulkUpdateResult,
         BulkUpdateUpsertResult, CollectionConfig, Index, IndexOption, Indexes, Model, Repository,
         SortOrder,
+        repository::MongodmCollectionExt, ToRepository,
     };
     #[doc(no_inline)]
     pub use futures_util::future::{BoxFuture, FutureExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod prelude {
         f, field, operator::*, pipeline, sync_indexes, BulkUpdate, BulkUpdateResult,
         BulkUpdateUpsertResult, CollectionConfig, Index, IndexOption, Indexes, Model, Repository,
         SortOrder,
-        repository::MongodmCollectionExt, ToRepository,
+        repository::CollectionExt, ToRepository,
     };
     #[doc(no_inline)]
     pub use futures_util::future::{BoxFuture, FutureExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,7 +225,7 @@ pub mod prelude {
         f, field, operator::*, pipeline, sync_indexes, BulkUpdate, BulkUpdateResult,
         BulkUpdateUpsertResult, CollectionConfig, Index, IndexOption, Indexes, Model, Repository,
         SortOrder,
-        repository::CollectionExt, ToRepository,
+        repository::CollectionExt as _, ToRepository as _,
     };
     #[doc(no_inline)]
     pub use futures_util::future::{BoxFuture, FutureExt};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ pub mod operator;
 pub mod repository;
 
 pub use index::{sync_indexes, Index, IndexOption, Indexes, SortOrder};
-pub use repository::{BulkUpdate, BulkUpdateResult, BulkUpdateUpsertResult, Repository};
+pub use repository::{BulkUpdate, BulkUpdateResult, BulkUpdateUpsertResult, Repository, CollectionExt};
 
 // Re-export mongodb
 pub use mongodb as mongo;

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -231,7 +231,11 @@ impl<M: Model> Repository<M> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
+    /// use mongodm::prelude::*;
+    /// /* ... */
+    /// let repository: Repository<M> = <...>;
+    /// /* ... */
     /// let bulk_update_res = repository
     ///     .bulk_update(&vec![
     ///         &BulkUpdate {
@@ -263,13 +267,11 @@ impl<M: Model> Repository<M> {
 
 #[async_trait]
 pub trait CollectionExt {
-    async fn bulk_update<V, U>(&self, db: &MongoDatabase, updates: V) -> Result<BulkUpdateResult>
+    async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
     where
         V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
         U: 'async_trait + Send + Sync + Borrow<BulkUpdate>;
 }
-
-use crate::prelude::MongoDatabase;
 
 #[async_trait]
 impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
@@ -280,11 +282,14 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     ///
     /// # Example
     ///
-    /// ```ignore
+    /// ```no_run
     /// use mongodm::prelude::*;
     /// /* ... */
+    /// let db: mongodb::Database = <...>;
+    /// let collection: mongodb::Collection<M> = <...>;
+    /// /* ... */
     /// let bulk_update_res = collection
-    ///     .bulk_update(&vec![
+    ///     .bulk_update(&db, &vec![
     ///         &BulkUpdate {
     ///             query: doc! { f!(name in User): "Dane" },
     ///             update: doc! { Set: { f!(age in User): 12 } },
@@ -301,7 +306,7 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// assert_eq!(bulk_update_res.nb_affected, 2);
     /// assert_eq!(bulk_update_res.nb_modified, 2);
     /// ```
-    async fn bulk_update<V, U>(&self, db: &MongoDatabase, updates: V) -> Result<BulkUpdateResult>
+    async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
     where
         V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
         U: 'async_trait + Send + Sync + Borrow<BulkUpdate>,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -1,6 +1,7 @@
 //! Repositories are abstraction over a specific mongo collection for a given `Model`
 
 use crate::{CollectionConfig, Model};
+use async_trait::async_trait;
 use mongodb::bson::oid::ObjectId;
 use mongodb::bson::{doc, from_document, to_bson, Document};
 use mongodb::error::Result;
@@ -251,8 +252,59 @@ impl<M: Model> Repository<M> {
     /// ```
     pub async fn bulk_update<V, U>(&self, updates: V) -> Result<BulkUpdateResult>
     where
-        V: Borrow<Vec<U>>,
-        U: Borrow<BulkUpdate>,
+        M: Send + Sync,
+        V: Borrow<Vec<U>> + Send + Sync,
+        U: Borrow<BulkUpdate> + Send + Sync,
+    {
+        Ok(self.coll.bulk_update(&self.db, updates).await?)
+    }
+}
+
+
+#[async_trait]
+pub trait MongodmCollectionExt {
+    async fn bulk_update<V, U>(&self, db: &MongoDatabase, updates: V) -> Result<BulkUpdateResult>
+    where
+        V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
+        U: 'async_trait + Send + Sync + Borrow<BulkUpdate>;
+}
+
+use crate::prelude::MongoDatabase;
+
+#[async_trait]
+impl<M: Send + Sync> MongodmCollectionExt for mongodb::Collection<M> {
+    /// Apply multiple update operations in bulk.
+    ///
+    /// This will be removed once support for bulk update is added to the official driver.
+    /// [see](https://jira.mongodb.org/browse/RUST-531) for tracking progress on this feature in the official driver.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// use mongodm::prelude::*;
+    /// /* ... */
+    /// let bulk_update_res = collection
+    ///     .bulk_update(&vec![
+    ///         &BulkUpdate {
+    ///             query: doc! { f!(name in User): "Dane" },
+    ///             update: doc! { Set: { f!(age in User): 12 } },
+    ///             options: None,
+    ///         },
+    ///         &BulkUpdate {
+    ///             query: doc! { f!(name in User): "David" },
+    ///             update: doc! { Set: { f!(age in User): 30 } },
+    ///             options: None,
+    ///         },
+    ///     ])
+    ///     .await
+    ///     .unwrap();
+    /// assert_eq!(bulk_update_res.nb_affected, 2);
+    /// assert_eq!(bulk_update_res.nb_modified, 2);
+    /// ```
+    async fn bulk_update<V, U>(&self, db: &MongoDatabase, updates: V) -> Result<BulkUpdateResult>
+    where
+        V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
+        U: 'async_trait + Send + Sync + Borrow<BulkUpdate>,
     {
         let updates = updates.borrow();
         let mut update_docs = Vec::with_capacity(updates.len());
@@ -280,13 +332,13 @@ impl<M: Model> Repository<M> {
             update_docs.push(doc);
         }
         let mut command = doc! {
-            "update": self.collection_name(),
+            "update": self.name(),
             "updates": update_docs,
         };
-        if let Some(ref write_concern) = self.db.write_concern() {
+        if let Some(ref write_concern) = self.write_concern() {
             command.insert("writeConcern", to_bson(write_concern)?);
         }
-        let res = self.db.run_command(command, None).await?;
+        let res = db.run_command(command, None).await?;
         Ok(from_document(res)?)
     }
 }

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -247,10 +247,9 @@ impl<M: Model> Repository<M> {
     /// # }
     /// use mongodm::prelude::*;
     /// /* ... */
-    /// # async fn demo() {
+    /// # async fn demo(_db: mongodb::Database) {
     /// let db: mongodb::Database; /* exists */
-    /// # let client = MongoClient::with_uri_str("test").await.unwrap();
-    /// # db = client.database("test");
+    /// # db = _db;
     /// let repository = db.repository::<User>();
     /// /* ... */
     /// let bulk_update_res = repository
@@ -271,8 +270,6 @@ impl<M: Model> Repository<M> {
     /// assert_eq!(bulk_update_res.nb_affected, 2);
     /// assert_eq!(bulk_update_res.nb_modified, 2);
     /// # }
-    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
-    /// # rt.block_on(demo());
     /// ```
     pub async fn bulk_update<V, U>(&self, updates: V) -> Result<BulkUpdateResult>
     where
@@ -304,10 +301,9 @@ pub trait CollectionExt {
     /// # }
     /// use mongodm::prelude::*;
     /// /* ... */
-    /// # async fn demo() {
+    /// # async fn demo(_db: mongodb::Database) {
     /// let db: mongodb::Database; /* exists */
-    /// # let client = MongoClient::with_uri_str("test").await.unwrap();
-    /// # db = client.database("test");
+    /// # db = _db;
     /// let collection = db.collection::<User>("user");
     /// /* ... */
     /// let bulk_update_res = collection
@@ -328,8 +324,6 @@ pub trait CollectionExt {
     /// assert_eq!(bulk_update_res.nb_affected, 2);
     /// assert_eq!(bulk_update_res.nb_modified, 2);
     /// # }
-    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
-    /// # rt.block_on(demo());
     /// ```
     async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
     where

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -249,7 +249,7 @@ impl<M: Model> Repository<M> {
     /// /* ... */
     /// # async fn demo() {
     /// let db: mongodb::Database; /* exists */
-    /// # let client = MongoClient::with_uri_str("uri").await.unwrap();
+    /// # let client = MongoClient::with_uri_str("test").await.unwrap();
     /// # db = client.database("test");
     /// let repository = db.repository::<User>();
     /// /* ... */
@@ -285,16 +285,9 @@ impl<M: Model> Repository<M> {
 }
 
 
+/// MongODM-provided utilities functions on `mongodb::Collection<M>`.
 #[async_trait]
 pub trait CollectionExt {
-    async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
-    where
-        V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
-        U: 'async_trait + Send + Sync + Borrow<BulkUpdate>;
-}
-
-#[async_trait]
-impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// Apply multiple update operations in bulk.
     ///
     /// This will be removed once support for bulk update is added to the official driver.
@@ -313,7 +306,7 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// /* ... */
     /// # async fn demo() {
     /// let db: mongodb::Database; /* exists */
-    /// # let client = MongoClient::with_uri_str("uri").await.unwrap();
+    /// # let client = MongoClient::with_uri_str("test").await.unwrap();
     /// # db = client.database("test");
     /// let collection = db.collection::<User>("user");
     /// /* ... */
@@ -338,6 +331,14 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
     /// # rt.block_on(demo());
     /// ```
+    async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
+    where
+        V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
+        U: 'async_trait + Send + Sync + Borrow<BulkUpdate>;
+}
+
+#[async_trait]
+impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
     where
         V: 'async_trait + Send + Sync + Borrow<Vec<U>>,

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -232,9 +232,26 @@ impl<M: Model> Repository<M> {
     /// # Example
     ///
     /// ```no_run
+    /// # use serde::{Serialize, Deserialize};
+    /// # #[derive(Serialize, Deserialize)]
+    /// # struct User {
+    /// #     name: String,
+    /// #     age: i64,
+    /// # }
+    /// # impl Model for User {
+    /// #     type CollConf = UserCollConf;
+    /// # }
+    /// # struct UserCollConf;
+    /// # impl CollectionConfig for UserCollConf {
+    /// #     fn collection_name() -> &'static str { "user" }
+    /// # }
     /// use mongodm::prelude::*;
     /// /* ... */
-    /// let repository: Repository<M> = <...>;
+    /// # async fn demo() {
+    /// let db: mongodb::Database; /* exists */
+    /// # let client = MongoClient::with_uri_str("uri").await.unwrap();
+    /// # db = client.database("test");
+    /// let repository = db.repository::<User>();
     /// /* ... */
     /// let bulk_update_res = repository
     ///     .bulk_update(&vec![
@@ -253,6 +270,9 @@ impl<M: Model> Repository<M> {
     ///     .unwrap();
     /// assert_eq!(bulk_update_res.nb_affected, 2);
     /// assert_eq!(bulk_update_res.nb_modified, 2);
+    /// # }
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
+    /// # rt.block_on(demo());
     /// ```
     pub async fn bulk_update<V, U>(&self, updates: V) -> Result<BulkUpdateResult>
     where
@@ -283,10 +303,19 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// # Example
     ///
     /// ```no_run
+    /// # use serde::{Serialize, Deserialize};
+    /// # #[derive(Serialize, Deserialize)]
+    /// # struct User {
+    /// #     name: String,
+    /// #     age: i64,
+    /// # }
     /// use mongodm::prelude::*;
     /// /* ... */
-    /// let db: mongodb::Database = <...>;
-    /// let collection: mongodb::Collection<M> = <...>;
+    /// # async fn demo() {
+    /// let db: mongodb::Database; /* exists */
+    /// # let client = MongoClient::with_uri_str("uri").await.unwrap();
+    /// # db = client.database("test");
+    /// let collection = db.collection::<User>("user");
     /// /* ... */
     /// let bulk_update_res = collection
     ///     .bulk_update(&db, &vec![
@@ -305,6 +334,9 @@ impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     ///     .unwrap();
     /// assert_eq!(bulk_update_res.nb_affected, 2);
     /// assert_eq!(bulk_update_res.nb_modified, 2);
+    /// # }
+    /// # let mut rt = tokio::runtime::Runtime::new().unwrap();
+    /// # rt.block_on(demo());
     /// ```
     async fn bulk_update<V, U>(&self, db: &mongodb::Database, updates: V) -> Result<BulkUpdateResult>
     where

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -262,7 +262,7 @@ impl<M: Model> Repository<M> {
 
 
 #[async_trait]
-pub trait MongodmCollectionExt {
+pub trait CollectionExt {
     async fn bulk_update<V, U>(&self, db: &MongoDatabase, updates: V) -> Result<BulkUpdateResult>
     where
         V: 'async_trait + Send + Sync + Borrow<Vec<U>>,
@@ -272,7 +272,7 @@ pub trait MongodmCollectionExt {
 use crate::prelude::MongoDatabase;
 
 #[async_trait]
-impl<M: Send + Sync> MongodmCollectionExt for mongodb::Collection<M> {
+impl<M: Send + Sync> CollectionExt for mongodb::Collection<M> {
     /// Apply multiple update operations in bulk.
     ///
     /// This will be removed once support for bulk update is added to the official driver.


### PR DESCRIPTION
Expose additionnal functionnalities provided by our Repository<T> object to the native mongodb Collection<T> object as an extension trait.

This keeps backward compatibility and keep the model versionning abilities of MongODM's Repository object, but also exposes our additionnal functionnalities (for now only bulk_update) to the native Collection itself, allowing users not using model versionning to directly use the native mongodb API.