### PR TITLE
feat(deps)!: upgrade odm layer to MongDB Rust driver v3.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodm"
-version = "0.9.2"
+version = "1.0.0"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2021"
 description = "A thin ODM layer for mongodb"
@@ -25,7 +25,7 @@ pretty_assertions = "1.0.0"
 chrono = { version = "0.4.38", features = [ "serde" ] }
 
 #[features]
-#default = ["mongodb/rustls-tls"]
+#default = ["tokio-runtime"]
 #tokio-runtime = ["mongodb/tokio-runtime"]
 #async-std-runtime = ["mongodb/async-std-runtime"]
 #chrono-0_4 = ["mongodb/bson-chrono-0_4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,15 +17,8 @@ serde = { version = "1", features = ["derive"] }
 futures-core = "0.3"
 futures-util = "0.3"
 async-trait = "0.1"
-#tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 tokio = "1.14.0"
 pretty_assertions = "1.0.0"
 chrono = { version = "0.4.38", features = [ "serde" ] }
-
-#[features]
-#default = ["tokio-runtime"]
-#tokio-runtime = ["mongodb/tokio-runtime"]
-#async-std-runtime = ["mongodb/async-std-runtime"]
-#chrono-0_4 = ["mongodb/bson-chrono-0_4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,20 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
-mongodb = { version = "2", default-features = false }
+mongodb = { version = "3", default-features = true }
 serde = { version = "1", features = ["derive"] }
 futures-core = "0.3"
 futures-util = "0.3"
 async-trait = "0.1"
+#tokio = { version = "1", features = ["full"] }
 
 [dev-dependencies]
 tokio = "1.14.0"
 pretty_assertions = "1.0.0"
-chrono = { version = "0.4.19", features = [ "serde" ] }
+chrono = { version = "0.4.38", features = [ "serde" ] }
 
-[features]
-default = ["tokio-runtime"]
-tokio-runtime = ["mongodb/tokio-runtime"]
-async-std-runtime = ["mongodb/async-std-runtime"]
-chrono-0_4 = ["mongodb/bson-chrono-0_4"]
+#[features]
+#default = ["mongodb/rustls-tls"]
+#tokio-runtime = ["mongodb/tokio-runtime"]
+#async-std-runtime = ["mongodb/async-std-runtime"]
+#chrono-0_4 = ["mongodb/bson-chrono-0_4"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mongodm"
-version = "1.0.0"
+version = "0.10.0"
 authors = ["Benoît CORTIER <benoit.cortier@fried-world.eu>"]
 edition = "2021"
 description = "A thin ODM layer for mongodb"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,21 +136,21 @@ pub trait CollectionConfig {
 /// Utilities methods to get a `Repository`. Implemented for `mongodb::Database`.
 pub trait ToRepository {
     /// Shorthand for `Repository::<Model>::new`.
-    fn repository<M: Model>(&self) -> Repository<M>;
+    fn repository<M: Model + Send + Sync>(&self) -> Repository<M>;
 
     /// Shorthand for `Repository::<Model>::new_with_options`.
-    fn repository_with_options<M: Model>(
+    fn repository_with_options<M: Model + Send + Sync>(
         &self,
         options: mongodb::options::CollectionOptions,
     ) -> Repository<M>;
 }
 
 impl ToRepository for mongodb::Database {
-    fn repository<M: Model>(&self) -> Repository<M> {
+    fn repository<M: Model + Send + Sync>(&self) -> Repository<M> {
         Repository::new(self.clone())
     }
 
-    fn repository_with_options<M: Model>(
+    fn repository_with_options<M: Model + Send + Sync>(
         &self,
         options: mongodb::options::CollectionOptions,
     ) -> Repository<M> {
@@ -178,13 +178,14 @@ pub mod prelude {
         JavaScriptCodeWithScope as BsonJavaScriptCodeWithScope, Regex as BsonRegex,
         Serializer as BsonSerializer, Timestamp as BsonTimestamp,
     };
+    //See driver pull request change for errors: https://github.com/mongodb/mongo-rust-driver/pull/1102
     #[doc(no_inline)]
     pub use crate::mongo::{
         error::{
-            BulkWriteError as MongoBulkWriteError, BulkWriteFailure as MongoBulkWriteFailure,
-            CommandError as MongoCommandError, Error as MongoError, ErrorKind as MongoErrorKind,
-            WriteConcernError as MongoWriteConcernError, WriteError as MongoWriteError,
-            WriteFailure as MongoWriteFailure,
+            BulkWriteError as MongoBulkWriteError, CommandError as MongoCommandError,
+            Error as MongoError, ErrorKind as MongoErrorKind,
+            InsertManyError as MongoInsertManyError, WriteConcernError as MongoWriteConcernError,
+            WriteError as MongoWriteError, WriteFailure as MongoWriteFailure,
         },
         options::{
             Acknowledgment as MongoAcknowledgment, AggregateOptions as MongoAggregateOptions,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,8 +128,8 @@ pub trait CollectionConfig {
     /// Configure how indexes should be created and synchronized for the associated collection.
     ///
     /// This method has a default implementation returning no index (only special `_id` index will be present).
-    fn indexes() -> index::Indexes {
-        index::Indexes::default()
+    fn indexes() -> Indexes {
+        Indexes::default()
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,7 +108,7 @@ pub use mongodb::bson;
 pub use mongodb::bson::{bson, doc};
 
 /// Associate a collection configuration.
-pub trait Model: serde::ser::Serialize + serde::de::DeserializeOwned + Unpin {
+pub trait Model: serde::ser::Serialize + serde::de::DeserializeOwned + Unpin + Send + Sync {
     type CollConf: CollectionConfig;
 }
 
@@ -136,21 +136,21 @@ pub trait CollectionConfig {
 /// Utilities methods to get a `Repository`. Implemented for `mongodb::Database`.
 pub trait ToRepository {
     /// Shorthand for `Repository::<Model>::new`.
-    fn repository<M: Model + Send + Sync>(&self) -> Repository<M>;
+    fn repository<M: Model>(&self) -> Repository<M>;
 
     /// Shorthand for `Repository::<Model>::new_with_options`.
-    fn repository_with_options<M: Model + Send + Sync>(
+    fn repository_with_options<M: Model>(
         &self,
         options: mongodb::options::CollectionOptions,
     ) -> Repository<M>;
 }
 
 impl ToRepository for mongodb::Database {
-    fn repository<M: Model + Send + Sync>(&self) -> Repository<M> {
+    fn repository<M: Model>(&self) -> Repository<M> {
         Repository::new(self.clone())
     }
 
-    fn repository_with_options<M: Model + Send + Sync>(
+    fn repository_with_options<M: Model>(
         &self,
         options: mongodb::options::CollectionOptions,
     ) -> Repository<M> {
@@ -178,7 +178,7 @@ pub mod prelude {
         JavaScriptCodeWithScope as BsonJavaScriptCodeWithScope, Regex as BsonRegex,
         Serializer as BsonSerializer, Timestamp as BsonTimestamp,
     };
-    //See driver pull request change for errors: https://github.com/mongodb/mongo-rust-driver/pull/1102
+
     #[doc(no_inline)]
     pub use crate::mongo::{
         error::{

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -43,21 +43,19 @@ pub struct BulkUpdateUpsertResult {
 /// This type can safely be copied and passed around because `std::sync::Arc` is used internally.
 /// Underlying `mongodb::Collection` can be retrieved at anytime with `Repository::get_underlying`.
 #[derive(Debug)]
-pub struct Repository<M: Model + Send + Sync> {
+pub struct Repository<M: Model> {
     db: mongodb::Database, // FIXME: temporary keep reference to database object for `bulk_update` operation
     coll: mongodb::Collection<M>,
 }
 
-impl<M: Model + Send + Sync> Deref for Repository<M> {
+impl<M: Model> Deref for Repository<M> {
     type Target = mongodb::Collection<M>;
     fn deref(&self) -> &mongodb::Collection<M> {
         &self.coll
     }
 }
 
-impl<M: Model + Send + Sync> Clone
-    for Repository<M>
-{
+impl<M: Model> Clone for Repository<M> {
     fn clone(&self) -> Self {
         Self {
             db: self.db.clone(),
@@ -66,7 +64,7 @@ impl<M: Model + Send + Sync> Clone
     }
 }
 
-impl<M: Model + Send + Sync> Repository<M> {
+impl<M: Model> Repository<M> {
     /// Create a new repository from the given mongo client.
     pub fn new(db: mongodb::Database) -> Self {
         let coll = if let Some(options) = M::CollConf::collection_options() {
@@ -222,9 +220,7 @@ impl<M: Model + Send + Sync> Repository<M> {
     /// ```
     pub fn cast_model<OtherModel>(self) -> Repository<OtherModel>
     where
-        OtherModel: Model<CollConf = M::CollConf>
-            + Send
-            + Sync
+        OtherModel: Model<CollConf = M::CollConf>,
     {
         Repository {
             db: self.db,
@@ -281,7 +277,6 @@ impl<M: Model + Send + Sync> Repository<M> {
     /// ```
     pub async fn bulk_update<V, U>(&self, updates: V) -> Result<BulkUpdateResult>
     where
-        M: Send + Sync,
         V: Borrow<Vec<U>> + Send + Sync,
         U: Borrow<BulkUpdate> + Send + Sync,
     {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -66,29 +66,7 @@ impl<M: Model + std::marker::Send + std::marker::Sync + std::marker::Sync + std:
     }
 }
 
-impl<
-        M: Model
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Send
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync
-            + std::marker::Sync,
-    > Repository<M>
-{
+impl<M: Model + Send + Sync> Repository<M> {
     /// Create a new repository from the given mongo client.
     pub fn new(db: mongodb::Database) -> Self {
         let coll = if let Some(options) = M::CollConf::collection_options() {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -48,14 +48,14 @@ pub struct Repository<M: Model + Send + Sync> {
     coll: mongodb::Collection<M>,
 }
 
-impl<M: Model + std::marker::Send + std::marker::Sync> Deref for Repository<M> {
+impl<M: Model + Send + Sync> Deref for Repository<M> {
     type Target = mongodb::Collection<M>;
     fn deref(&self) -> &mongodb::Collection<M> {
         &self.coll
     }
 }
 
-impl<M: Model + std::marker::Send + std::marker::Sync + std::marker::Sync + std::marker::Sync> Clone
+impl<M: Model + Send + Sync> Clone
     for Repository<M>
 {
     fn clone(&self) -> Self {
@@ -223,9 +223,8 @@ impl<M: Model + Send + Sync> Repository<M> {
     pub fn cast_model<OtherModel>(self) -> Repository<OtherModel>
     where
         OtherModel: Model<CollConf = M::CollConf>
-            + std::marker::Send
-            + std::marker::Sync
-            + std::marker::Sync,
+            + Send
+            + Sync
     {
         Repository {
             db: self.db,

--- a/tests/indexes.rs
+++ b/tests/indexes.rs
@@ -28,17 +28,14 @@ async fn one_sync() {
     let db = client.database("rust_mongo_orm_tests");
 
     db.collection::<Document>(OneSyncCollConf::collection_name())
-        .drop(None)
+        .drop()
         .await
         .unwrap();
 
     sync_indexes::<OneSyncCollConf>(&db).await.unwrap();
 
     let ret = db
-        .run_command(
-            doc! { "listIndexes": OneSyncCollConf::collection_name() },
-            None,
-        )
+        .run_command(doc! { "listIndexes": OneSyncCollConf::collection_name() })
         .await
         .unwrap();
 
@@ -123,17 +120,14 @@ async fn multiple_sync() {
     let db = client.database("rust_mongo_orm_tests");
 
     db.collection::<Document>(MultipleSyncCollConf::collection_name())
-        .drop(None)
+        .drop()
         .await
         .unwrap();
 
     sync_indexes::<MultipleSyncCollConf>(&db).await.unwrap();
 
     let ret = db
-        .run_command(
-            doc! { "listIndexes": MultipleSyncCollConf::collection_name() },
-            None,
-        )
+        .run_command(doc! { "listIndexes": MultipleSyncCollConf::collection_name() })
         .await
         .unwrap();
 
@@ -173,10 +167,7 @@ async fn multiple_sync() {
         .unwrap();
 
     let ret = db
-        .run_command(
-            doc! { "listIndexes": MultipleNoLastSeenCollConf::collection_name() },
-            None,
-        )
+        .run_command(doc! { "listIndexes": MultipleNoLastSeenCollConf::collection_name() })
         .await
         .unwrap();
 
@@ -215,10 +206,7 @@ async fn multiple_sync() {
         .unwrap();
 
     let ret = db
-        .run_command(
-            doc! { "listIndexes": MultipleNotUniqueCollConf::collection_name() },
-            None,
-        )
+        .run_command(doc! { "listIndexes": MultipleNotUniqueCollConf::collection_name() })
         .await
         .unwrap();
 

--- a/tests/some_operations.rs
+++ b/tests/some_operations.rs
@@ -40,7 +40,7 @@ async fn insert_delete_find() {
     let db = client.database("rust_mongo_orm_tests");
 
     let repository = db.repository::<User>();
-    repository.drop(None).await.unwrap();
+    repository.drop().await.unwrap();
     sync_indexes::<UserCollConf>(&db).await.unwrap();
 
     let users = vec![
@@ -81,10 +81,10 @@ async fn insert_delete_find() {
         },
     ];
 
-    repository.insert_many(users, None).await.unwrap();
+    repository.insert_many(users).await.unwrap();
 
     let user_dane = repository
-        .find_one(doc! { f!(name in User): "Dane" }, None)
+        .find_one(doc! { f!(name in User): "Dane" })
         .await
         .unwrap()
         .unwrap();
@@ -93,19 +93,19 @@ async fn insert_delete_find() {
     assert_eq!(user_dane.info, "d");
 
     let found = repository
-        .find(doc! { f!(age in User): { LesserThan: 40 } }, None)
+        .find(doc! { f!(age in User): { LesserThan: 40 } })
         .await
         .unwrap();
     let found: Vec<mongodb::error::Result<User>> = found.collect().await;
     assert_eq!(found.len(), 4);
 
     repository
-        .delete_one(doc! { f!(age in User): { LesserThan: 38 } }, None)
+        .delete_one(doc! { f!(age in User): { LesserThan: 38 } })
         .await
         .unwrap();
 
     let found = repository
-        .find(doc! { f!(age in User): { LesserThan: 40 } }, None)
+        .find(doc! { f!(age in User): { LesserThan: 40 } })
         .await
         .unwrap();
     let found: Vec<mongodb::error::Result<User>> = found.collect().await;
@@ -122,7 +122,7 @@ async fn bulk_updates() {
     let db = client.database("rust_mongo_orm_tests");
 
     let repository = db.repository::<User>();
-    repository.drop(None).await.unwrap();
+    repository.drop().await.unwrap();
     sync_indexes::<UserCollConf>(&db).await.unwrap();
 
     let users = vec![
@@ -163,7 +163,7 @@ async fn bulk_updates() {
         },
     ];
 
-    repository.insert_many(users, None).await.unwrap();
+    repository.insert_many(users).await.unwrap();
 
     let bulk_update_res = repository
         .bulk_update(&vec![
@@ -184,7 +184,7 @@ async fn bulk_updates() {
     assert_eq!(bulk_update_res.nb_modified, 2);
 
     let user_dane = repository
-        .find_one(doc! { f!(name in User): "Dane" }, None)
+        .find_one(doc! { f!(name in User): "Dane" })
         .await
         .unwrap()
         .unwrap();
@@ -192,7 +192,7 @@ async fn bulk_updates() {
     assert_eq!(user_dane.age, 12);
 
     let user_dane = repository
-        .find_one(doc! { f!(name in User): "David" }, None)
+        .find_one(doc! { f!(name in User): "David" })
         .await
         .unwrap()
         .unwrap();


### PR DESCRIPTION
This pull request is related to that issue below I have opened to switch to the newer version of Mongodb Rust Driver **v3.0.0**
Issue : https://github.com/Devolutions/mongodm-rs/issues/29

Mongodb team introduced a lot of broken changes as a regard to  the former api in 2.x. Some methods have their arguments reduced, or some errors have been renamed. A lot of refactoring resulted in having build errors for features that have been also removed in Cargo.

This pull request is opened to address those. 
I have run the Unit test and it ran successfully. Feel free to review, fix, accept or deny this PR. 

Here is one of the PR from Mongodb Driver Rust team from which originates those broken changes from the APIs: https://github.com/mongodb/mongo-rust-driver/pull/1046
**FindOptions, FindOneOptions** and so on  are removed from find method arguments and  encapsulated by chain calling explicitly a with_options()
```rust
db.collection.find_one(doc).with_options(find_one_options) ;
db.collection.insert_one(&doc).with_options(insert_options).session(session);
```

![image](https://github.com/Devolutions/mongodm-rs/assets/11457752/e0abff38-8ada-431a-a5e4-f762a5318baf)

Additional PR from mongodb rust team with broken changes from the former 2.x api: //See driver pull request change for errors: https://github.com/mongodb/mongo-rust-driver/pull/1102
