### PR TITLE
feat: add bson3 feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 env:
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ windows, linux ]
+        os: [windows, linux]
         include:
           - os: windows
             runner: windows-latest
@@ -55,11 +55,14 @@ jobs:
       - name: Rust cache
         uses: Swatinem/rust-cache@v2.7.3
 
+      - name: Lints (compat-3-0-0)
+        run: cargo clippy --workspace --no-default-features --features compat-3-0-0 -v -- -Dwarnings
+
+      - name: Lints (compat-3-3-0)
+        run: cargo clippy --workspace --no-default-features --features compat-3-3-0 -v -- -Dwarnings
+
       - name: Tests
         run: cargo test --workspace -v
-
-      - name: Lints
-        run: cargo clippy --workspace -v -- -Dwarnings
 
   success:
     name: Success

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,13 @@ categories = ["database"]
 readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
+[features]
+default = ["compat-3-0-0"]
+compat-3-0-0 = ["mongodb/compat-3-0-0"]
+compat-3-3-0 = ["mongodb/compat-3-3-0", "mongodb/bson-3"]
+
 [dependencies]
-mongodb = { version = "3", default-features = true }
+mongodb = { version = "3", default-features = false, features = ["dns-resolver", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 futures-core = "0.3"
 futures-util = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,10 +170,14 @@ impl ToRepository for mongodb::Database {
 /// // ...
 /// ```
 pub mod prelude {
-    #[doc(no_inline)]
+    #[cfg(feature = "compat-3-0-0")]
+    pub use mongodb::bson::de::Error as BsonDeserializeError;
+    #[cfg(feature = "compat-3-3-0")]
+    pub use mongodb::bson::error::Error as BsonError;
+
+    pub use crate::mongo::bson::oid::ObjectId;
     pub use crate::mongo::bson::{
-        bson, de::Error as BsonDeError, doc, from_bson, oid::ObjectId, ser::Error as BsonSerError,
-        to_bson, Binary as BsonBinary, Bson, DateTime as BsonDateTime,
+        bson, doc, Binary as BsonBinary, Bson, DateTime as BsonDateTime,
         Deserializer as BsonDeserializer, Document as BsonDocument,
         JavaScriptCodeWithScope as BsonJavaScriptCodeWithScope, Regex as BsonRegex,
         Serializer as BsonSerializer, Timestamp as BsonTimestamp,


### PR DESCRIPTION
[mongo 3.4.1](https://docs.rs/crate/mongodb/3.4.1/features) uses bson 2 by default via the `compat-3-0-0` feature. However, there is support for bson 3 in `compat-3-3-0`.

This adds the ability to use bson 3 just like the upstream mongodb driver.

Changes:
- sets mongodb `default-features` from true to false
- adds two features, `compat-3-0-0` and `compat-3-3-0`
  - feature names are the same as upstream
  - the default is bson 2/`compat-3.0.0`, just like upstream
- CI builds for both features