### PR TITLE
feat: add openssl feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.3
 
       - name: Lints (compat-3-0-0)
-        run: cargo clippy --workspace --no-default-features --features compat-3-0-0 -v -- -Dwarnings
+        run: cargo clippy --workspace --no-default-features --features "compat-3-0-0 openssl" -v -- -Dwarnings
 
       - name: Lints (compat-3-3-0)
-        run: cargo clippy --workspace --no-default-features --features compat-3-3-0 -v -- -Dwarnings
+        run: cargo clippy --workspace --no-default-features --features "compat-3-3-0 openssl" -v -- -Dwarnings
 
       - name: Tests
         run: cargo test --workspace -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,10 @@ jobs:
         uses: Swatinem/rust-cache@v2.7.3
 
       - name: Lints (compat-3-0-0)
-        run: cargo clippy --workspace --no-default-features --features "compat-3-0-0 openssl" -v -- -Dwarnings
+        run: cargo clippy --workspace --no-default-features --features "compat-3-0-0 rustls" -v -- -Dwarnings
 
       - name: Lints (compat-3-3-0)
-        run: cargo clippy --workspace --no-default-features --features "compat-3-3-0 openssl" -v -- -Dwarnings
+        run: cargo clippy --workspace --no-default-features --features "compat-3-3-0 rustls" -v -- -Dwarnings
 
       - name: Tests
         run: cargo test --workspace -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ readme = "README.md"
 include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [features]
-default = ["compat-3-0-0"]
+default = ["compat-3-0-0", "rustls"]
 compat-3-0-0 = ["mongodb/compat-3-0-0"]
 compat-3-3-0 = ["mongodb/compat-3-3-0", "mongodb/bson-3"]
+openssl = ["mongodb/openssl-tls"]
+rustls = ["mongodb/rustls-tls"]
 
 [dependencies]
-mongodb = { version = "3", default-features = false, features = ["dns-resolver", "rustls-tls"] }
+mongodb = { version = "3", default-features = false, features = ["dns-resolver"] }
 serde = { version = "1", features = ["derive"] }
 futures-core = "0.3"
 futures-util = "0.3"


### PR DESCRIPTION
This adds `openssl` and `rustls` features which toggle the feature on the
mongodb driver.
Upstream default (rustls) is retained.

This PR is on top of #36.