### PR TITLE
ci: add release-plz workflow for automated releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
   workflow_dispatch:

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -1,0 +1,58 @@
+name: Release crates
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  # Create a PR with the new versions and changelog, preparing the next release.
+  open-pr:
+    name: Open release PR
+    runs-on: ubuntu-latest
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 512
+
+      - name: Run release-plz
+        id: release-plz
+        uses: Devolutions/actions-public/release-plz@v1
+        with:
+          command: release-pr
+          git-name: Devolutions Bot
+          git-email: bot@devolutions.net
+          github-token: ${{ secrets.DEVOLUTIONSBOT_WRITE_TOKEN }}
+
+  # Release unpublished packages.
+  release:
+    name: Release crates
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 512
+
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      - name: Run release-plz
+        uses: Devolutions/actions-public/release-plz@v1
+        with:
+          command: release
+          registry-token: ${{ steps.auth.outputs.token }}

--- a/.github/workflows/release-crates.yml
+++ b/.github/workflows/release-crates.yml
@@ -44,8 +44,6 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          fetch-depth: 512
 
       - name: Authenticate with crates.io
         id: auth

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,94 @@
+# Configuration file for git-cliff
+
+[changelog]
+trim = false
+
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+"""
+
+# https://tera.netlify.app/docs/#introduction
+body = """
+{% if version -%}
+  ## [[{{ version | trim_start_matches(pat="v") }}]{%- if release_link -%}({{ release_link }}){% endif %}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{%- else -%}
+  ## [Unreleased]
+{%- endif %}
+
+{% for group, commits in commits | group_by(attribute="group") -%}
+
+### {{ group | upper_first }}
+
+{%- for commit in commits %}
+
+{%- set message = commit.message | upper_first %}
+
+{%- if commit.breaking %}
+  {%- set breaking = "[**breaking**] " %}
+{%- else %}
+  {%- set breaking = "" %}
+{%- endif %}
+
+{%- set short_sha = commit.id | truncate(length=10, end="") %}
+{%- set commit_url = "https://github.com/Devolutions/mongodm-rs/commit/" ~ commit.id %}
+{%- set commit_link = "[" ~ short_sha ~ "](" ~ commit_url ~ ")" %}
+
+- {{ breaking }}{{ message }} ({{ commit_link }}) \
+  {% if commit.body %}\n\n  {{ commit.body | replace(from="\n", to="\n  ") }}{% endif %}
+{%- endfor %}
+
+{% endfor -%}
+"""
+
+footer = ""
+
+[git]
+conventional_commits = true
+filter_unconventional = false
+filter_commits = false
+date_order = false
+protect_breaking_commits = true
+sort_commits = "oldest"
+
+commit_preprocessors = [
+  # Replace the issue number with the link.
+  { pattern = "\\(#([0-9]+)\\)", replace = "([#${1}](https://github.com/Devolutions/mongodm-rs/issues/${1}))" },
+  # Replace commit sha1 with the link.
+  { pattern = '([a-f0-9]{10})([a-f0-9]{30})', replace = "[${0}](https://github.com/Devolutions/mongodm-rs/commit/${1}${2})" },
+]
+
+# regex for parsing and grouping commits
+# <!-- <NUMBER> --> is a trick to control the section order: https://github.com/orhun/git-cliff/issues/9#issuecomment-914521594
+commit_parsers = [
+  { message = "^chore", skip = true },
+  { message = "^style", skip = true },
+  { message = "^refactor", skip = true },
+  { message = "^test", skip = true },
+  { message = "^ci", skip = true },
+  { message = "^chore\\(release\\): prepare for", skip = true },
+  { footer = "^[Cc]hangelog: ?ignore", skip = true },
+
+  { message = "(?i)security", group = "<!-- 0 -->Security" },
+  { body = "(?i)security", group = "<!-- 0 -->Security" },
+  { footer = "^[Ss]ecurity: ?yes", group = "<!-- 0 -->Security" },
+
+  { message = "^feat", group = "<!-- 1 -->Features" },
+
+  { message = "^revert", group = "<!-- 3 -->Revert" },
+  { message = "^fix", group = "<!-- 4 -->Bug Fixes" },
+  { message = "^perf", group = "<!-- 5 -->Performance" },
+  { message = "^doc", group = "<!-- 6 -->Documentation" },
+  { message = "^build", group = "<!-- 7 -->Build" },
+
+  { message = "(?i)improve", group = "<!-- 2 -->Improvements" },
+  { message = "(?i)adjust", group = "<!-- 2 -->Improvements" },
+  { message = "(?i)change", group = "<!-- 2 -->Improvements" },
+
+  { message = ".*", group = "<!-- 99 -->Please Sort" },
+]

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,8 @@
+[workspace]
+dependencies_update = true
+git_release_enable = true
+semver_check = true
+pr_branch_prefix = "release-plz/"
+pr_name = "chore(release): prepare for publishing"
+changelog_config = "cliff.toml"
+release_commits = "^(feat|docs|fix|build|perf)"


### PR DESCRIPTION
Implements release-plz workflow similar to IronRDP, which will:
- Automatically create PRs with version bumps and changelog updates
- Publish releases to crates.io using trusted publisher authentication
- Generate changelogs following Keep a Changelog format